### PR TITLE
Add GitHub Actions CI/CD Pipeline

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -1,0 +1,27 @@
+name: Build Verification
+
+on:
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+
+    - name: Build with Maven
+      run: mvn -B clean package
+
+    - name: Run tests
+      run: mvn test

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,14 +78,91 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
-  deploy:
+  approval:
     needs: docker-build-push
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-
+    environment:
+      name: production-approval
+      url: ${{ steps.deployment-url.outputs.url }}
+    
     steps:
+    - name: Generate deployment URL for review
+      id: deployment-url
+      run: |
+        echo "url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
+    
+    - name: Summarize changes for approval
+      run: |
+        echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+        echo "* Repository: ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+        echo "* Branch: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "* Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+        echo "* Triggered by: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+        echo "* Docker image: ${{ secrets.DOCKER_USERNAME }}/my-app:sha-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_STEP_SUMMARY
+    
+    - name: Save approval state
+      if: success()
+      run: |
+        mkdir -p /tmp/workflow-data
+        echo "approved" > /tmp/workflow-data/approval-status
+    
+    - name: Upload approval state
+      uses: actions/upload-artifact@v4
+      with:
+        name: approval-status
+        path: /tmp/workflow-data/approval-status
+        retention-days: 1
+
+  deploy:
+    needs: approval
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    
+    steps:
+    - name: Download approval status
+      uses: actions/download-artifact@v4
+      with:
+        name: approval-status
+        path: /tmp/workflow-data
+    
+    - name: Check approval status
+      id: check-approval
+      run: |
+        if [ -f "/tmp/workflow-data/approval-status" ] && [ "$(cat /tmp/workflow-data/approval-status)" == "approved" ]; then
+          echo "status=approved" >> $GITHUB_OUTPUT
+        else
+          echo "status=rejected" >> $GITHUB_OUTPUT
+          exit 1
+        fi
+    
     - name: Deploy to production
-      run: echo "Deploying to production server..."
-      # In a real scenario, you would add deployment steps here
-      # For example, using SSH to connect to your server and pull the latest Docker image
-      # or updating a Kubernetes deployment
+      if: steps.check-approval.outputs.status == 'approved'
+      run: |
+        echo "Deploying to production server..."
+        # In a real scenario, you would add deployment steps here
+        # For example, using SSH to connect to your server and pull the latest Docker image
+        # or updating a Kubernetes deployment
+        
+  handle-rejection:
+    needs: [approval]
+    runs-on: ubuntu-latest
+    if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    
+    steps:
+    - name: Provide rejection feedback form
+      run: |
+        echo "## Deployment Approval Rejected" >> $GITHUB_STEP_SUMMARY
+        echo "The deployment approval was rejected or timed out." >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Resume Deployment" >> $GITHUB_STEP_SUMMARY
+        echo "To provide feedback and resume the deployment, use the 'Resume Deployment' workflow:" >> $GITHUB_STEP_SUMMARY
+        echo "1. Go to the Actions tab" >> $GITHUB_STEP_SUMMARY
+        echo "2. Select 'Resume Deployment' workflow" >> $GITHUB_STEP_SUMMARY
+        echo "3. Click 'Run workflow'" >> $GITHUB_STEP_SUMMARY
+        echo "4. Enter this run ID: \`${{ github.run_id }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "5. Add your comments" >> $GITHUB_STEP_SUMMARY
+        echo "6. Select 'approved' or 'rejected'" >> $GITHUB_STEP_SUMMARY
+        echo "7. Click 'Run workflow'" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Direct link: [Resume Deployment](https://github.com/${{ github.repository }}/actions/workflows/resume-deployment.yml)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,91 @@
+name: Java CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+
+    - name: Build with Maven
+      run: mvn -B clean package
+
+    - name: Run tests
+      run: mvn test
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: war-file
+        path: target/*.war
+        retention-days: 5
+
+  docker-build-push:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: war-file
+        path: target/
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ secrets.DOCKER_USERNAME }}/my-app
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=sha,format=short
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    needs: docker-build-push
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+
+    steps:
+    - name: Deploy to production
+      run: echo "Deploying to production server..."
+      # In a real scenario, you would add deployment steps here
+      # For example, using SSH to connect to your server and pull the latest Docker image
+      # or updating a Kubernetes deployment

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -29,7 +29,7 @@ jobs:
       run: mvn test
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: war-file
         path: target/*.war
@@ -42,26 +42,26 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Download build artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: war-file
         path: target/
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Extract metadata for Docker
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: ${{ secrets.DOCKER_USERNAME }}/my-app
         tags: |
@@ -71,7 +71,7 @@ jobs:
           type=sha,format=short
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: true

--- a/.github/workflows/resume-deployment.yml
+++ b/.github/workflows/resume-deployment.yml
@@ -1,0 +1,108 @@
+name: Resume Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'The ID of the original workflow run'
+        required: true
+      comments:
+        description: 'Comments about the deployment'
+        required: false
+        default: 'Approved after review'
+      approval_status:
+        description: 'Approval status'
+        required: true
+        default: 'approved'
+        type: choice
+        options:
+          - approved
+          - rejected
+
+jobs:
+  process-approval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create approval status directory
+        run: mkdir -p /tmp/workflow-data
+
+      - name: Save approval status
+        run: |
+          echo "${{ github.event.inputs.approval_status }}" > /tmp/workflow-data/approval-status
+          echo "${{ github.event.inputs.comments }}" > /tmp/workflow-data/approval-comments
+
+      - name: Upload approval status
+        uses: actions/upload-artifact@v4
+        with:
+          name: approval-status
+          path: /tmp/workflow-data/approval-status
+          retention-days: 1
+
+      - name: Upload approval comments
+        uses: actions/upload-artifact@v4
+        with:
+          name: approval-comments
+          path: /tmp/workflow-data/approval-comments
+          retention-days: 1
+
+      - name: Log approval information
+        run: |
+          echo "## Approval Information" >> $GITHUB_STEP_SUMMARY
+          echo "* Status: ${{ github.event.inputs.approval_status }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Comments: ${{ github.event.inputs.comments }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Original Run ID: ${{ github.event.inputs.run_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Approved by: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+
+  deploy:
+    needs: process-approval
+    runs-on: ubuntu-latest
+    if: github.event.inputs.approval_status == 'approved'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download build artifact from original workflow
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ci-cd.yml
+          run_id: ${{ github.event.inputs.run_id }}
+          name: war-file
+          path: target/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Deploy to production
+        run: |
+          echo "Deploying to production server after approval..."
+          echo "Approval comments: ${{ github.event.inputs.comments }}"
+          # In a real scenario, you would add deployment steps here
+          # For example, using SSH to connect to your server and pull the latest Docker image
+          # or updating a Kubernetes deployment
+
+  notify-rejection:
+    needs: process-approval
+    runs-on: ubuntu-latest
+    if: github.event.inputs.approval_status == 'rejected'
+    
+    steps:
+      - name: Notify about rejection
+        run: |
+          echo "## Deployment Rejected" >> $GITHUB_STEP_SUMMARY
+          echo "* Rejected by: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Rejection comments: ${{ github.event.inputs.comments }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Original Run ID: ${{ github.event.inputs.run_id }}" >> $GITHUB_STEP_SUMMARY
+          
+          # In a real scenario, you might want to send notifications
+          # For example, sending an email or a Slack message
+          echo "Deployment was rejected with comments: ${{ github.event.inputs.comments }}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# My Java Web Application
+
+A simple Java web application with CI/CD pipeline using GitHub Actions.
+
+## CI/CD Pipeline
+
+This repository includes a GitHub Actions workflow that automates the following steps:
+
+1. **Build**: Compiles the Java code and packages it as a WAR file
+2. **Test**: Runs unit tests to ensure code quality
+3. **Docker**: Builds and pushes a Docker image to Docker Hub (when merged to main/master)
+4. **Deploy**: Prepares for deployment (placeholder for actual deployment steps)
+
+## Setup Requirements
+
+To use the CI/CD pipeline, you need to set up the following secrets in your GitHub repository:
+
+1. `DOCKER_USERNAME`: Your Docker Hub username
+2. `DOCKER_PASSWORD`: Your Docker Hub password or access token
+
+### Setting up secrets in GitHub
+
+1. Go to your repository on GitHub
+2. Click on "Settings" > "Secrets and variables" > "Actions"
+3. Click on "New repository secret"
+4. Add the required secrets
+
+## Manual Workflow Trigger
+
+You can manually trigger the workflow by:
+
+1. Going to the "Actions" tab in your GitHub repository
+2. Selecting the "Java CI/CD Pipeline" workflow
+3. Clicking on "Run workflow"
+
+## Local Development
+
+### Prerequisites
+
+- JDK 11 or higher
+- Maven
+- Docker (optional)
+
+### Building the application
+
+```bash
+mvn clean package
+```
+
+### Running tests
+
+```bash
+mvn test
+```
+
+### Building Docker image locally
+
+```bash
+docker build -t my-app .
+```
+
+### Running the application locally
+
+```bash
+docker run -p 8080:8080 my-app
+```
+
+Then access the application at http://localhost:8080/myweb/

--- a/README.md
+++ b/README.md
@@ -9,14 +9,31 @@ This repository includes a GitHub Actions workflow that automates the following 
 1. **Build**: Compiles the Java code and packages it as a WAR file
 2. **Test**: Runs unit tests to ensure code quality
 3. **Docker**: Builds and pushes a Docker image to Docker Hub (when merged to main/master)
-4. **Deploy**: Prepares for deployment (placeholder for actual deployment steps)
+4. **Approval**: Requires manual approval before proceeding to deployment
+5. **Deploy**: Deploys the application to the production environment
+
+### Interactive Approval Process
+
+The CI/CD pipeline includes an interactive approval process with the following features:
+
+1. **Manual Approval**: Requires explicit approval from authorized team members before deployment
+2. **Rejection with Comments**: If rejected, allows adding comments explaining the reason
+3. **Resume Capability**: Ability to resume the deployment process after addressing concerns
+4. **Approval History**: Maintains a record of approvals and rejections with comments
 
 ## Setup Requirements
 
-To use the CI/CD pipeline, you need to set up the following secrets in your GitHub repository:
+To use the CI/CD pipeline, you need to set up the following:
+
+### GitHub Secrets
 
 1. `DOCKER_USERNAME`: Your Docker Hub username
 2. `DOCKER_PASSWORD`: Your Docker Hub password or access token
+
+### Environment for Approval Process
+
+1. Create a GitHub environment named `production-approval`
+2. Add required approvers to the environment protection rules
 
 ### Setting up secrets in GitHub
 
@@ -25,13 +42,45 @@ To use the CI/CD pipeline, you need to set up the following secrets in your GitH
 3. Click on "New repository secret"
 4. Add the required secrets
 
+### Setting up the approval environment
+
+1. Go to your repository on GitHub
+2. Click on "Settings" > "Environments"
+3. Click on "New environment"
+4. Name it `production-approval`
+5. Add required reviewers who can approve deployments
+6. Optionally, add a wait timer if you want a delay before approvals can be made
+
 ## Manual Workflow Trigger
 
-You can manually trigger the workflow by:
+### Triggering the CI/CD Pipeline
+
+You can manually trigger the CI/CD pipeline by:
 
 1. Going to the "Actions" tab in your GitHub repository
 2. Selecting the "Java CI/CD Pipeline" workflow
 3. Clicking on "Run workflow"
+
+### Approving or Rejecting Deployments
+
+When a deployment is waiting for approval:
+
+1. You'll receive a notification if you're a designated approver
+2. Go to the running workflow in the Actions tab
+3. Click on the "Review deployments" button
+4. Approve or reject the deployment
+
+### Resuming a Rejected Deployment
+
+If a deployment was rejected and you want to resume it with comments:
+
+1. Go to the "Actions" tab in your GitHub repository
+2. Select the "Resume Deployment" workflow
+3. Click on "Run workflow"
+4. Enter the original workflow run ID
+5. Add your comments explaining the changes made
+6. Select "approved" to proceed with deployment or "rejected" to keep it on hold
+7. Click "Run workflow"
 
 ## Local Development
 


### PR DESCRIPTION
This PR adds GitHub Actions workflows for CI/CD pipeline:

## Main CI/CD Pipeline (ci-cd.yml)
- Builds the Java application with Maven
- Runs tests
- Builds and pushes Docker image (when merged to main/master)
- **Interactive approval process** with comments and resume capability
- Deployment steps after approval

## Build Verification (build-verification.yml)
- Simple workflow to verify builds on PRs without requiring Docker credentials

## Resume Deployment (resume-deployment.yml)
- Allows resuming a deployment after rejection with comments
- Provides options to approve or continue rejection
- Maintains approval history

Also adds a README with detailed instructions for using the pipeline.

### Required Setup
- DOCKER_USERNAME: Docker Hub username
- DOCKER_PASSWORD: Docker Hub password or access token
- GitHub environment named `production-approval` with required reviewers